### PR TITLE
Deprecated Express Plugin

### DIFF
--- a/examples/azure-functions/host.json
+++ b/examples/azure-functions/host.json
@@ -11,5 +11,6 @@
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[3.15.0, 4.0.0)"
-  }
+  },
+  "watchDirectories": [ "dist" ]
 }

--- a/examples/azure-functions/package.json
+++ b/examples/azure-functions/package.json
@@ -5,9 +5,10 @@
   "main": "dist/src/main.js",
   "scripts": {
     "build": "tsc",
+    "build:watch": "tsc --watch",
     "lint": "tsc --noEmit",
-    "start": "tsc && func start",
-    "dev": "cross-env NODE_ENV=development tsx watch src/main.ts"
+    "start": "func start",
+    "dev": "run-p build:watch start"
   },
   "author": "Thada Wangthammang",
   "license": "MIT",


### PR DESCRIPTION
- [X] PoC using `host.json` prop, nammed `watchDirectories` instead of dev mode.
- [ ] Deprecated Express Plugin
- [ ] Apply to all examples
- [ ] Remove express plugin from `nammatham` package